### PR TITLE
Fix: Fixed timezones displayed on the Launch details page

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, getUserTimezone } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -114,6 +115,8 @@ function Header({ launch }) {
 }
 
 function TimeAndLocation({ launch }) {
+  const { locale, timeZone } = getUserTimezone();
+
   return (
     <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
       <Stat>
@@ -124,7 +127,9 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip label={formatDateTime(launch.launch_date_local, locale, timeZone)} aria-label="Timezone Tooltip">
+            {formatDateTime(launch.launch_date_local)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -18,3 +18,7 @@ export function formatDateTime(timestamp) {
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
+
+export function getUserTimezone() {
+  return new Intl.DateTimeFormat().resolvedOptions();
+}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -7,8 +7,8 @@ export function formatDate(timestamp) {
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
-  return new Intl.DateTimeFormat("en-US", {
+export function formatDateTime(timestamp, locale="en-US", timezone="UTC") {
+  return new Intl.DateTimeFormat(locale, {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -16,6 +16,7 @@ export function formatDateTime(timestamp) {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
+    timeZone: timezone
   }).format(new Date(timestamp));
 }
 


### PR DESCRIPTION
### What has changed:

- The timezone displayed on the Launch details page is now the local timezone of the launch site.
- A tooltip with the user's local timezone is displayed when hovering the original timezone information.